### PR TITLE
fix: remove BleakClient.pair() call that breaks BLE on no-PIN devices

### DIFF
--- a/custom_components/meshtastic/aiomeshtastic/connection/bluetooth.py
+++ b/custom_components/meshtastic/aiomeshtastic/connection/bluetooth.py
@@ -76,15 +76,6 @@ class BluetoothConnection(ClientApiConnection):
             )
             await self._bleak_client.connect()
 
-        # attempt pairing, we don't know if it is required. Should not harm if
-        # not needed. if pairing is required, external input is necessary as we are not
-        # able to fully pair with bleak see https://github.com/hbldh/bleak/issues/1434.
-        # possible workaround: https://technotes.kynetics.com/2018/pairing_agents_bluez/
-        try:
-            await self._bleak_client.pair()
-        except:  # noqa: E722
-            self._logger.debug("Pairing failed", exc_info=True)
-
         self._ble_meshtastic_service = self._bleak_client.services[BluetoothConnection.BTM_SERVICE_UUID]
 
         if self._ble_meshtastic_service is None:


### PR DESCRIPTION
## Summary

- Removes the `BleakClient.pair()` call in `BluetoothConnection._connect()` that causes ATT error 0x0e ("Unlikely Error") on Meshtastic devices with Bluetooth PIN disabled
- The `pair()` call corrupts the GATT connection state on Linux/BlueZ, causing all subsequent characteristic reads/notifications to fail
- This is the required configuration since PIN support is not yet implemented (#37)

## Details

The `pair()` call was intended as best-effort ("should not harm if not needed"), but on devices without PIN:

1. `pair()` triggers an ATT protocol error 0x0e on the BlueZ stack
2. Although caught by the bare `except`, the pairing attempt corrupts the BLE connection state
3. Subsequent GATT operations (`start_notify`, `read_gatt_char`) fail with `BleakDBusError` or `NotConnected`
4. The integration reports "Unable to connect to the device" and never completes setup

`bluetoothctl connect` works fine from the host — the issue is specifically the `pair()` call from within Bleak/habluetooth.

For devices that *do* require pairing, the `pair()` call also did not work reliably due to Bleak limitations ([hbldh/bleak#1434](https://github.com/hbldh/bleak/issues/1434)), as noted in the removed comment.

## Testing

Tested on:
- HAOS 17.1 / HA 2026.3.4 (aarch64, Raspberry Pi 5)
- Meshtastic integration v0.6.1
- Elecrow ThinkNode-M4 with BLE enabled, PIN disabled
- RPi built-in BCM43438 Bluetooth adapter (hci0)

Before: "Unable to connect to the device" every time
After: Connection succeeds, integration sets up normally

Fixes #99
Related: #37

## Test plan

- [ ] Verify BLE connection succeeds on device with PIN disabled
- [ ] Verify BLE connection still succeeds on device with PIN enabled (if tester has one)
- [ ] Verify GATT characteristic reads/writes work after connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)