### PR TITLE
Expose PDOP/HDOP/VDOP as device_tracker attributes

### DIFF
--- a/custom_components/meshtastic/device_tracker.py
+++ b/custom_components/meshtastic/device_tracker.py
@@ -115,7 +115,7 @@ class MeshtasticDeviceTracker(MeshtasticNodeEntity, TrackerEntity):
         self._attr_extra_state_attributes = {
             k: v
             for k, v in position.items()
-            if k in ["altitude", "groundSpeed", "groundTrack", "locationSource", "satsInView"]
+            if k in ["altitude", "groundSpeed", "groundTrack", "locationSource", "satsInView", "PDOP", "HDOP", "VDOP"]
         }
 
     @property

--- a/custom_components/meshtastic/device_tracker.py
+++ b/custom_components/meshtastic/device_tracker.py
@@ -55,6 +55,9 @@ async def async_unload_entry(
     return await helpers.async_unload_entry(hass, entry)
 
 
+_DOP_ATTRIBUTES = ("PDOP", "HDOP", "VDOP")
+
+
 class MeshtasticDeviceTracker(MeshtasticNodeEntity, TrackerEntity):
     entity_description: TrackerEntityDescription
 
@@ -112,10 +115,11 @@ class MeshtasticDeviceTracker(MeshtasticNodeEntity, TrackerEntity):
         self._attr_latitude = position.get("latitude", None)
         self._attr_longitude = position.get("longitude", None)
         self._attr_location_accuracy = self._precision_to_meters.get(precision_bits, 0)
+        # PDOP/HDOP/VDOP are transmitted in 1/100 units, convert to actual DOP values
         self._attr_extra_state_attributes = {
-            k: v
+            k: v / 100 if k in _DOP_ATTRIBUTES else v
             for k, v in position.items()
-            if k in ["altitude", "groundSpeed", "groundTrack", "locationSource", "satsInView", "PDOP", "HDOP", "VDOP"]
+            if k in ["altitude", "groundSpeed", "groundTrack", "locationSource", "satsInView", *_DOP_ATTRIBUTES]
         }
 
     @property


### PR DESCRIPTION
The `Position` protobuf carries dilution-of-precision values whenever a node’s `position_flags` include `DOP`, but `_async_update_attrs()` filters them out of `extra_state_attributes`, so fix quality never reaches Home Assistant.

```python
if k in ["altitude", "groundSpeed", "groundTrack", "locationSource", "satsInView"]
```

This adds `PDOP`, `HDOP` and `VDOP` to that allowlist. One line, no behaviour change for existing attributes.

### Why `gps_accuracy` does not already cover this

```python
self._attr_location_accuracy = self._precision_to_meters.get(precision_bits, 0)
```

That value comes from `precisionBits` — the channel’s deliberate coordinate rounding — not from the quality of the GNSS fix. On a private channel at full precision it is always `0`, which reads as “perfect accuracy” while saying nothing at all about the fix.

### Why it matters in practice

I run a `TRACKER` node whose reported positions occasionally land a few hundred metres away. Those outliers are bad fixes, not relay or ordering artefacts — during one walk the reported altitude jumped to 72, 83 and 103 m while every other sample that day sat between −8 and +17 m, and the satellite count dropped from 17–21 to 13–16. With DOP exposed, that is a single attribute to threshold on instead of inferring it from altitude sanity.

Note that with `HVDOP` unset a node sends the combined `PDOP`; setting it makes the node send `HDOP`/`VDOP` instead, so all three are included. Values are in 1/100 units per `mesh.proto`.

### Testing

Running on Home Assistant 2026.8.1 against a SenseCAP T1000-E with `position_flags = 827`. `HDOP` now appears on the `device_tracker` entity (observed 0.66–0.89 on good fixes). `ruff format` reports the file unchanged and `ruff check` shows no new findings — the pre-existing `CPY001` on this file is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device tracker details now include PDOP, HDOP, and VDOP positioning accuracy values when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->