### PR TITLE
fix(web): answer 404 for an unknown config entry instead of 500

### DIFF
--- a/custom_components/meshtastic/meshtastic_web/__init__.py
+++ b/custom_components/meshtastic/meshtastic_web/__init__.py
@@ -251,6 +251,8 @@ class MeshtasticWebConfigEntryView(HomeAssistantView):
         path = f"{URL_BASE}/web/{entity.config_entry_id}"
 
         config_entry = self._hass.config_entries.async_get_entry(entity.config_entry_id)
+        if config_entry is None:
+            return web.HTTPNotFound(headers={"Cache-Control": "no-cache"})
         if config_entry.state != ConfigEntryState.LOADED:
             return web.HTTPBadGateway(
                 body=f"Gateway is not ready (config entry state {config_entry.state.value})",
@@ -302,6 +304,16 @@ class MeshtasticWebApiV1View(HomeAssistantView):
 
     def _check_webclient_enabled(self, config_entry_id: str) -> None:
         config_entry = self._hass.config_entries.async_get_entry(config_entry_id)
+        if config_entry is None:
+            # The id comes straight from the URL, so a stale bookmark or a typo
+            # lands here. Without this guard the attribute access below raises
+            # AttributeError and the caller answers 500 with a stack trace
+            # instead of an honest 404.
+            raise web.HTTPNotFound(
+                text="Unknown config entry",
+                content_type="text/plain",
+                headers={"Cache-Control": "no-cache"},
+            )
         if config_entry.state != ConfigEntryState.LOADED:
             raise web.HTTPBadGateway(
                 body=f"Gateway is not ready (config entry state {config_entry.state.value})",


### PR DESCRIPTION
## Summary

`ConfigEntries.async_get_entry()` returns `None` for an id it does not know, and both call sites in the web client views read `.state` off the result immediately. The id comes straight from the URL, so a stale bookmark, a truncated copy-paste or a removed entry is enough to reach this path — and the caller gets a 500 with an `AttributeError` instead of a 404.

## Steps to reproduce

```
PUT /meshtastic/web/DOES_NOT_EXIST/api/v1/toradio
```

Any of the three web client endpoints will do; `_check_webclient_enabled` is called by `ToRadio.put`, `FromRadio.get` and `JsonReport.get`.

## What happens

```
500 Internal Server Error

  File "meshtastic_web/__init__.py", line 305, in _check_webclient_enabled
    if config_entry.state != ConfigEntryState.LOADED:
AttributeError: 'NoneType' object has no attribute 'state'
```

## What I expected

`404`, the way the neighbouring entity lookup already answers for an unknown entity.

## Notes

Both sites now check for `None` first. The index view **returns** `HTTPNotFound`, matching the entity-lookup guard three lines above it and the other responses in that method; `_check_webclient_enabled` **raises**, matching the `HTTPBadGateway` and `HTTPForbidden` it sits between.

Both responses carry `Cache-Control: no-cache` like every other response in these views. A 404 is heuristically cacheable, so without it a browser or reverse proxy could pin the gateway URL to 404 after the config entry comes back.

The body is a constant rather than an echo of the id: these views are `requires_auth = False`, so reflecting caller-supplied text would be unauthenticated echo, and it tells the caller nothing they did not just type. `text=` rather than `body=`, since aiohttp emits a `DeprecationWarning` for the latter.

This is more a diagnosis fix than a cosmetic one — a 500 with an `AttributeError` reads like a broken integration, while the real condition ("this id does not exist") is something the caller can act on.

## Verification

Against a live gateway on 0.6.1: an unknown id now returns `404 Unknown config entry` with the cache header, valid ids are unaffected, and the `AttributeError` no longer appears in the log. `ruff check` and `ruff format --check` are clean under the CI-pinned `ruff==0.11.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBSYkUUHPeCJ2DQLUv7wAb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid configuration entries in the web client and API.
  * Unknown entry IDs now return a clear HTTP 404 response instead of an internal server error.
  * Added no-cache headers to prevent caching invalid responses.
  * Strengthened authorization checks for API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->